### PR TITLE
Fixed a variable name error.

### DIFF
--- a/pages/config_page.php
+++ b/pages/config_page.php
@@ -87,7 +87,7 @@ print_manage_menu( 'manage_plugin_page.php' );
                                         $t_result      = Longman\TelegramBot\Request::getWebhookInfo();
                                         $t_webhook_url = $t_result->result->getUrl();
                                     } catch( Longman\TelegramBot\Exception\TelegramException $t_errors ) {
-                                        $t_webhook_url = $$t_errors->getMessage();
+                                        $t_webhook_url = $t_errors->getMessage();
                                     }
 
                                     if( $t_webhook_url ) {


### PR DESCRIPTION
Due to an error in the name of the $ t_errors variable, 
an error occurred on the config_page page in 
a situation where the bot token was specified with an error.

Fix #9