### PR TITLE
Added connection debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Features
     - change the status of the bug;
     - adding a comment to the bug;
     - mention of the user in the commentary.
-- Respond to chat alerts about events using the built-in function "Reply to message". The answer will be added as a comment to the bug (v. >= 1.3).
-- Support SOCKS5 proxy server.
+- Respond to chat alerts about events using the built-in function "Reply to message". The answer will be added as a comment to the bug (v. >= 1.3);
+- Support SOCKS5 proxy server ( Requires curl >= 7.21.7 ).
 
 Download
 --------

--- a/TelegramBot.php
+++ b/TelegramBot.php
@@ -22,7 +22,7 @@ class TelegramBotPlugin extends MantisPlugin {
         $this->name        = 'TelegramBot';
         $this->description = plugin_lang_get( 'description' );
 
-        $this->version  = '1.3.3';
+        $this->version  = '1.4.0';
         $this->requires = array(
                                   'MantisCore' => '2.14.0',
         );
@@ -85,6 +85,7 @@ class TelegramBotPlugin extends MantisPlugin {
         require_once 'core/TelegramBot_fields_api.php';
         require_once 'core/TelegramBot_message_api.php';
         require_once 'core/TelegramBot_message_format_api.php';
+	require_once 'core/TelegramBot_menu_api.php';
 
         global $g_skip_sending_bugnote, $g_account_telegram_menu_active;
         $g_skip_sending_bugnote         = FALSE;
@@ -100,6 +101,8 @@ class TelegramBotPlugin extends MantisPlugin {
                                   'download_path'                             => '/tmp/',
 				  'proxy_address'				=> '',
 				  'time_out_server_response'			=> 30,
+				  'debug_connection_log_path'			=> '/tmp/TelegramBot_debug.log',
+				  'debug_connection_enabled'			=> OFF,
                                   /**
                                    * The following two config options allow you to control who should get email
                                    * notifications on different actions/statuses.  The first option

--- a/core/TelegramBot_authentication_api.php
+++ b/core/TelegramBot_authentication_api.php
@@ -54,14 +54,18 @@ function telegram_session_start() {
 
 	if( $g_tg == NULL ) {
 		$g_tg = new \Longman\TelegramBot\Telegram( plugin_config_get( 'api_key' ), plugin_config_get( 'bot_name' ) );
-		
+
 		\Longman\TelegramBot\Request::setClient( new \GuzzleHttp\Client( [
 					  'base_uri'	 => 'https://api.telegram.org',
 					  'timeout'	 => plugin_config_get( 'time_out_server_response' ),
-					  'proxy'	 => 'socks5://' . plugin_config_get( 'proxy_address' ),
+					  'proxy'		 => 'socks5://' . plugin_config_get( 'proxy_address' ),
 		] ) );
-		
+
 		$g_tg->setDownloadPath( plugin_config_get( 'download_path' ) );
+
+		if( plugin_config_get( 'debug_connection_enabled' ) == ON ) {
+			Longman\TelegramBot\TelegramLog::initDebugLog( plugin_config_get( 'debug_connection_log_path' ) );
+		}
 	}
 }
 

--- a/core/TelegramBot_authentication_api.php
+++ b/core/TelegramBot_authentication_api.php
@@ -55,11 +55,18 @@ function telegram_session_start() {
 	if( $g_tg == NULL ) {
 		$g_tg = new \Longman\TelegramBot\Telegram( plugin_config_get( 'api_key' ), plugin_config_get( 'bot_name' ) );
 
-		\Longman\TelegramBot\Request::setClient( new \GuzzleHttp\Client( [
-					  'base_uri'	 => 'https://api.telegram.org',
-					  'timeout'	 => plugin_config_get( 'time_out_server_response' ),
-					  'proxy'		 => 'socks5://' . plugin_config_get( 'proxy_address' ),
-		] ) );
+		$t_proxy_address = plugin_config_get( 'proxy_address' );
+
+		$t_client_prop = array();
+
+		$t_client_prop['base_uri']	 = 'https://api.telegram.org';
+		$t_client_prop['timeout']	 = plugin_config_get( 'time_out_server_response' );
+
+		if( !is_blank( $t_proxy_address ) ) {
+			$t_client_prop['proxy'] = 'socks5://' . $t_proxy_address;
+		}
+
+		\Longman\TelegramBot\Request::setClient( new \GuzzleHttp\Client( $t_client_prop ) );
 
 		$g_tg->setDownloadPath( plugin_config_get( 'download_path' ) );
 

--- a/core/TelegramBot_menu_api.php
+++ b/core/TelegramBot_menu_api.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+function telegrambot_print_menu_config( $p_page = '' ) {
+	$t_pages = array(
+				  'config_page',
+				  'monitor_page',
+	);
+
+	if( access_has_global_level( config_get( 'manage_plugin_threshold' ) ) ) {
+		?>
+		<div class="col-md-12 col-xs-12">
+		    <div class="space-10"></div>
+		    <div class="left">
+			<div class="btn-toolbar inline">
+			    <div class="btn-group">
+				<?php
+				foreach( $t_pages as $t_page ) {
+					$t_active = ( ( $t_page === $p_page ) ? ' active' : '' );
+					?>
+					<a class="btn btn-sm btn-white btn-primary<?php echo $t_active ?>" href="<?php echo plugin_page( $t_page ) ?>">
+					    <?php echo plugin_lang_get( $t_page ) ?>
+					</a>
+
+					<?php
+				}
+				?>
+
+			    </div>
+			</div>
+		    </div>
+		</div>
+		<?php
+	}
+}

--- a/core/TelegramBot_user_api.php
+++ b/core/TelegramBot_user_api.php
@@ -24,6 +24,8 @@ function telegram_bot_associated_all_users_get() {
 			FROM " . $t_user_relationship_table;
     $t_results = db_query( $t_query );
 
+    $t_row = array();
+    
     foreach( $t_results as $t_result ) {
         $t_row[] = $t_result['mantis_user_id'];
     }

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -24,6 +24,10 @@ $s_plugin_TelegramBot_proxy_address_header = 'SOCKS5 proxy server address: socks
 $s_plugin_TelegramBot_time_out_server_response_header = 'Server response timeout (30 seconds by default):';
 $s_plugin_TelegramBot_current_config = 'The bot will send updates to the following URL:';
 $s_plugin_TelegramBot_response_from_telegram = 'Telegram server response: ';
+$s_plugin_TelegramBot_debug_connection_log_path_title = 'Path to log file';
+$s_plugin_TelegramBot_debug_connection_enabled = 'Enable connection debug mode?';
+$s_plugin_TelegramBot_config_page = 'General settings';
+$s_plugin_TelegramBot_monitor_page = 'Users monitor';
 
 $s_plugin_TelegramBot_bot_successfully_attached = 'The bot is successfully attached.';
 $s_plugin_TelegramBot_info_to_redirect_bot_page = 'Return to the chat, or wait for redirection.';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -28,6 +28,7 @@ $s_plugin_TelegramBot_debug_connection_log_path_title = 'Path to log file';
 $s_plugin_TelegramBot_debug_connection_enabled = 'Enable connection debug mode?';
 $s_plugin_TelegramBot_config_page = 'General settings';
 $s_plugin_TelegramBot_monitor_page = 'Users monitor';
+$s_plugin_TelegramBot_ERROR_CURL_VERSION = 'REQUIRED CURL >= 7.21.7 ';
 
 $s_plugin_TelegramBot_bot_successfully_attached = 'The bot is successfully attached.';
 $s_plugin_TelegramBot_info_to_redirect_bot_page = 'Return to the chat, or wait for redirection.';

--- a/lang/strings_russian.txt
+++ b/lang/strings_russian.txt
@@ -24,6 +24,10 @@ $s_plugin_TelegramBot_proxy_address_header = 'Адрес socks5 прокси с�
 $s_plugin_TelegramBot_time_out_server_response_header = 'Таймаут ожидания ответа сервера (по умолчанию 30 сек): ';
 $s_plugin_TelegramBot_current_config = 'Бот будет отправлять обновления на следующий URL:';
 $s_plugin_TelegramBot_response_from_telegram = 'Ответ сервера Telegram: ';
+$s_plugin_TelegramBot_debug_connection_log_path_title = 'Путь к лог файлу';
+$s_plugin_TelegramBot_debug_connection_enabled = 'Включить режим отладки подключения?';
+$s_plugin_TelegramBot_config_page = 'Общие настройки';
+$s_plugin_TelegramBot_monitor_page = 'Монитор пользователей';
 
 $s_plugin_TelegramBot_bot_successfully_attached = 'Бот успешно привязан.';
 $s_plugin_TelegramBot_info_to_redirect_bot_page = 'Вернитесь в чат, либо дождитесь переадресации.';

--- a/lang/strings_russian.txt
+++ b/lang/strings_russian.txt
@@ -28,6 +28,7 @@ $s_plugin_TelegramBot_debug_connection_log_path_title = 'Путь к лог фа
 $s_plugin_TelegramBot_debug_connection_enabled = 'Включить режим отладки подключения?';
 $s_plugin_TelegramBot_config_page = 'Общие настройки';
 $s_plugin_TelegramBot_monitor_page = 'Монитор пользователей';
+$s_plugin_TelegramBot_ERROR_CURL_VERSION = 'ТРЕБУЕТСЯ CURL >= 7.21.7 ';
 
 $s_plugin_TelegramBot_bot_successfully_attached = 'Бот успешно привязан.';
 $s_plugin_TelegramBot_info_to_redirect_bot_page = 'Вернитесь в чат, либо дождитесь переадресации.';

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -24,6 +24,10 @@ $s_plugin_TelegramBot_proxy_address_header = 'Dirección del servidor proxy SOCK
 $s_plugin_TelegramBot_time_out_server_response_header = 'Tiempo de espera de respuesta del servidor (30 segundos de forma predeterminada):';
 $s_plugin_TelegramBot_current_config = 'El bot enviará actualizaciones a la siguiente URL:';
 $s_plugin_TelegramBot_response_from_telegram = 'Respuesta del servidor de Telegram: ';
+$s_plugin_TelegramBot_debug_connection_log_path_title = 'Ruta al archivo de registro';
+$s_plugin_TelegramBot_debug_connection_enabled = 'Habilitar el modo de depuración de conexión?';
+$s_plugin_TelegramBot_config_page = 'Ajustes generales';
+$s_plugin_TelegramBot_monitor_page = 'Monitor de usuario';
 
 $s_plugin_TelegramBot_bot_successfully_attached = 'El robot está conectado correctamente.';
 $s_plugin_TelegramBot_info_to_redirect_bot_page = 'Regrese al chat, o espere la redirección.';

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -28,6 +28,7 @@ $s_plugin_TelegramBot_debug_connection_log_path_title = 'Ruta al archivo de regi
 $s_plugin_TelegramBot_debug_connection_enabled = 'Habilitar el modo de depuración de conexión?';
 $s_plugin_TelegramBot_config_page = 'Ajustes generales';
 $s_plugin_TelegramBot_monitor_page = 'Monitor de usuario';
+$s_plugin_TelegramBot_ERROR_CURL_VERSION = 'CURL NECESARIO >= 7.21.7 ';
 
 $s_plugin_TelegramBot_bot_successfully_attached = 'El robot está conectado correctamente.';
 $s_plugin_TelegramBot_info_to_redirect_bot_page = 'Regrese al chat, o espere la redirección.';

--- a/pages/config.php
+++ b/pages/config.php
@@ -1,5 +1,4 @@
 <?php
-
 # Copyright (c) 2018 Grigoriy Ermolaev (igflocal@gmail.com)
 # TelegramBot for MantisBT is free software: 
 # you can redistribute it and/or modify it under the terms of the GNU
@@ -15,6 +14,8 @@
 # along with Customer management plugin for MantisBT.  
 # If not, see <http://www.gnu.org/licenses/>.
 
+use Mantis\Exceptions\ClientException;
+
 form_security_validate( 'config' );
 
 global $g_tg;
@@ -23,21 +24,37 @@ $f_bot_name			 = gpc_get_string( 'bot_name' );
 $f_api_key			 = gpc_get_string( 'api_key' );
 $f_proxy_address		 = gpc_get_string( 'proxy_address', '' );
 $f_time_out_server_response	 = gpc_get_int( 'time_out_server_response' );
+$f_debug_connection_log_path	 = gpc_get_string( 'debug_connection_log_path', '' );
+$f_debug_connection_enabled	 = gpc_get_bool( 'debug_connection_enabled', FALSE );
 
 if( plugin_config_get( 'bot_name' ) != $f_bot_name ) {
-    plugin_config_set( 'bot_name', $f_bot_name );
+	plugin_config_set( 'bot_name', $f_bot_name );
 }
 
 if( plugin_config_get( 'api_key' ) != $f_api_key ) {
-    plugin_config_set( 'api_key', $f_api_key );
+	plugin_config_set( 'api_key', $f_api_key );
 }
 
 if( plugin_config_get( 'proxy_address' ) != $f_proxy_address ) {
-    plugin_config_set( 'proxy_address', $f_proxy_address );
+	plugin_config_set( 'proxy_address', $f_proxy_address );
 }
 
 if( plugin_config_get( 'time_out_server_response' ) != $f_time_out_server_response ) {
-    plugin_config_set( 'time_out_server_response', $f_time_out_server_response );
+	plugin_config_set( 'time_out_server_response', $f_time_out_server_response );
+}
+
+if( $f_debug_connection_enabled == ON ) {
+	if( is_writable( $f_debug_connection_log_path ) ) {
+		plugin_config_set( 'debug_connection_enabled', $f_debug_connection_enabled );
+		plugin_config_set( 'debug_connection_log_path', $f_debug_connection_log_path );
+	} else {
+		plugin_config_set( 'debug_connection_enabled', OFF );
+		plugin_config_set( 'debug_connection_log_path', $f_debug_connection_log_path );
+		throw new ClientException( 'Cannot access write file.', ERROR_FILE_INVALID_UPLOAD_PATH );
+	}
+} else {
+	plugin_config_set( 'debug_connection_enabled', OFF );
+	plugin_config_set( 'debug_connection_log_path', $f_debug_connection_log_path );
 }
 
 form_security_purge( plugin_page( 'config', true ) );

--- a/pages/config.php
+++ b/pages/config.php
@@ -44,7 +44,7 @@ if( plugin_config_get( 'time_out_server_response' ) != $f_time_out_server_respon
 }
 
 if( $f_debug_connection_enabled == ON ) {
-	if( is_writable( $f_debug_connection_log_path ) ) {
+	if( fopen( $f_debug_connection_log_path, 'a' ) ) {
 		plugin_config_set( 'debug_connection_enabled', $f_debug_connection_enabled );
 		plugin_config_set( 'debug_connection_log_path', $f_debug_connection_log_path );
 	} else {

--- a/pages/config_page.php
+++ b/pages/config_page.php
@@ -86,14 +86,30 @@ telegrambot_print_menu_config( 'config_page' );
                                     </td>
                                 </tr>
 				
-				<tr <?php echo helper_alternate_class() ?>>
-                                    <th class="category" width="5%">
-					<?php echo plugin_lang_get( 'proxy_address_header' ) ?>
-                                    </th>
-                                    <td class="center" colspan="1"> 
-                                        <textarea name="proxy_address" id="proxy_address" class="form-control" rows="1"><?php echo plugin_config_get( 'proxy_address' ) == NULL ? '' : plugin_config_get( 'proxy_address' ) ?></textarea>
-                                    </td>
-                                </tr>
+				<?php
+				$t_curl_version = curl_version();
+//				$t_curl_version = '7.19.7';
+				if( $t_curl_version['version'] >= '7.21.7' ) { ?>
+					<tr <?php echo helper_alternate_class() ?>>
+	                                    <th class="category" width="5%">
+						<?php echo plugin_lang_get( 'proxy_address_header' ) ?>
+	                                    </th>
+	                                    <td class="center" colspan="1"> 
+	                                        <textarea name="proxy_address" id="proxy_address" class="form-control" rows="1"><?php echo plugin_config_get( 'proxy_address' ) == NULL ? '' : plugin_config_get( 'proxy_address' ) ?></textarea>
+	                                    </td>
+	                                </tr>
+				<?php				
+				} else { ?>
+						<tr <?php echo helper_alternate_class() ?>>
+						    <th class="category" width="5%">
+							<?php echo plugin_lang_get( 'proxy_address_header' ) ?>
+						    </th>
+						    <td class="center" colspan="1"> 
+							<textarea name="proxy_address" id="proxy_address" class="form-control" rows="1" disabled="true"><?php echo plugin_lang_get( 'ERROR_CURL_VERSION' ) ?></textarea>
+						    </td>
+						</tr>
+					<?php
+				} ?>
 				
 				<tr <?php echo helper_alternate_class() ?>>
                                     <th class="category" width="5%">

--- a/pages/config_page.php
+++ b/pages/config_page.php
@@ -20,6 +20,7 @@ access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
 layout_page_header( plugin_lang_get( 'name_plugin_description_page' ) );
 layout_page_begin( 'manage_overview_page.php' );
 print_manage_menu( 'manage_plugin_page.php' );
+telegrambot_print_menu_config( 'config_page' );
 ?>
 
 <div class="col-md-12 col-xs-12">
@@ -93,61 +94,25 @@ print_manage_menu( 'manage_plugin_page.php' );
                                         <textarea name="proxy_address" id="proxy_address" class="form-control" rows="1"><?php echo plugin_config_get( 'proxy_address' ) == NULL ? '' : plugin_config_get( 'proxy_address' ) ?></textarea>
                                     </td>
                                 </tr>
-
-                                <?php
-                                $t_bot_name = plugin_config_get( 'bot_name' );
-                                $t_api_key  = plugin_config_get( 'api_key' );
-
-                                if( $t_bot_name && $t_api_key ) {
-
-                                    try {
-					telegram_session_start();
-                                        $t_result      = Longman\TelegramBot\Request::getWebhookInfo();
-                                        $t_webhook_url = $t_result->result->getUrl();
-                                    } catch( Longman\TelegramBot\Exception\TelegramException $t_errors ) {
-                                        $t_webhook_url = $t_errors->getMessage();
-                                    }
-
-                                    if( $t_webhook_url ) {
-                                        ?>
-
-                                        <tr <?php echo helper_alternate_class() ?>>
-                                            <td class="category" width="50%">
-                                                <?php echo plugin_lang_get( 'current_config' ) ?>
-                                            </td>
-
-                                            <td colspan="2">
-
-                                                <div class = "fallback">
-        <!--                                                    <pre>-->
-                                                    <?php
-                                                    print_r( $t_webhook_url );
-                                                    ?>
-                                                    <!--</pre>-->
-                                                </div>
-
-                                            </td>
-                                        </tr>
-                                        <?php
-                                    }
-                                }
-                                ?>
-
-                                <tr <?php echo helper_alternate_class() ?>>
+				
+				<tr <?php echo helper_alternate_class() ?>>
                                     <th class="category" width="5%">
-                                        <?php echo plugin_lang_get( 'account_telegram_prefs_associated_users_head' ) ?>
+					<?php echo plugin_lang_get( 'debug_connection_log_path_title' ) ?>
                                     </th>
-                                    <td class="left" colspan="1"> 
-
-                                        <p>
-                                            <?php
-                                            $t_associated_user_ids = telegram_bot_associated_all_users_get();
-                                            foreach( $t_associated_user_ids as $t_user_id ) {
-                                                echo user_get_field( $t_user_id, 'username' ) . '</br>';
-                                            }
-                                            ?>
-                                        </p>                                        
-
+                                    <td class="center" colspan="1"> 
+                                        <textarea name="debug_connection_log_path" id="debug_connection_log_path" class="form-control" rows="1"><?php echo plugin_config_get( 'debug_connection_log_path' ) ?></textarea>
+                                    </td>
+                                </tr>
+								
+				<tr <?php echo helper_alternate_class() ?>>
+                                    <th class="category" width="5%">
+					<?php echo plugin_lang_get( 'debug_connection_enabled' ) ?>
+                                    </th>
+                                    <td> 
+                                        <label class="inline">
+					    <input type="checkbox" class="ace" id="debug_connection_enabled" name="debug_connection_enabled" <?php check_checked( (int)plugin_config_get( 'debug_connection_enabled' ), ON ); ?> />
+					    <span class="lbl"></span>
+					</label>
                                     </td>
                                 </tr>
 

--- a/pages/monitor_page.php
+++ b/pages/monitor_page.php
@@ -1,0 +1,118 @@
+<?php
+# Copyright (c) 2018 Grigoriy Ermolaev (igflocal@gmail.com)
+# TelegramBot for MantisBT is free software: 
+# you can redistribute it and/or modify it under the terms of the GNU
+# General Public License as published by the Free Software Foundation, 
+# either version 2 of the License, or (at your option) any later version.
+#
+# TelegramBot plugin for for MantisBT is distributed in the hope 
+# that it will be useful, but WITHOUT ANY WARRANTY; without even the 
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Customer management plugin for MantisBT.  
+# If not, see <http://www.gnu.org/licenses/>.
+
+auth_reauthenticate();
+access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
+
+layout_page_header( plugin_lang_get( 'name_plugin_description_page' ) );
+layout_page_begin( 'manage_overview_page.php' );
+print_manage_menu( 'manage_plugin_page.php' );
+telegrambot_print_menu_config( 'monitor_page' );
+?>
+
+<div class="col-md-12 col-xs-12">
+    <div class="space-10"></div>
+    <div class="form-container">
+        <form action="<?php echo plugin_page( 'config' ) ?>" method="post" enctype="multipart/form-data"> 
+            <?php echo form_security_field( 'config' ) ?>
+            <div class="widget-box widget-color-blue2">
+                <div class="widget-header widget-header-small">
+                    <h4 class="widget-title lighter">
+                        <i class="ace-icon fa fa-cubes"></i>
+                        <?php echo plugin_lang_get( 'name_plugin_description_page' ) . ': ' . plugin_lang_get( 'monitor_page' ) ?>
+                    </h4>
+                </div>
+
+                <div class="widget-body">
+                    <div class="widget-main no-padding">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-bordered table-condensed table-hover">
+                                <colgroup>
+                                    <col style="width:25%" />
+                                </colgroup>
+
+
+                                <?php
+                                $t_bot_name = plugin_config_get( 'bot_name' );
+                                $t_api_key  = plugin_config_get( 'api_key' );
+
+                                if( $t_bot_name && $t_api_key ) {
+
+                                    try {
+					telegram_session_start();
+                                        $t_result      = Longman\TelegramBot\Request::getWebhookInfo();
+                                        $t_webhook_url = $t_result->result->getUrl();
+                                    } catch( Longman\TelegramBot\Exception\TelegramException $t_errors ) {
+                                        $t_webhook_url = $t_errors->getMessage();
+                                    }
+
+                                    if( $t_webhook_url ) {
+                                        ?>
+
+                                        <tr <?php echo helper_alternate_class() ?>>
+                                            <td class="category" width="50%">
+                                                <?php echo plugin_lang_get( 'current_config' ) ?>
+                                            </td>
+
+                                            <td colspan="2">
+
+                                                <div class = "fallback">
+        <!--                                                    <pre>-->
+                                                    <?php
+                                                    print_r( $t_webhook_url );
+                                                    ?>
+                                                    <!--</pre>-->
+                                                </div>
+
+                                            </td>
+                                        </tr>
+                                        <?php
+                                    }
+                                }
+                                ?>
+
+                                <tr <?php echo helper_alternate_class() ?>>
+                                    <th class="category" width="5%">
+                                        <?php echo plugin_lang_get( 'account_telegram_prefs_associated_users_head' ) ?>
+                                    </th>
+                                    <td class="left" colspan="1"> 
+
+                                        <p>
+                                            <?php
+                                            $t_associated_user_ids = telegram_bot_associated_all_users_get();
+                                            foreach( $t_associated_user_ids as $t_user_id ) {
+                                                echo user_get_field( $t_user_id, 'username' ) . '</br>';
+                                            }
+                                            ?>
+                                        </p>                                        
+
+                                    </td>
+                                </tr>
+
+
+                            </table>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php
+layout_page_end();
+


### PR DESCRIPTION
One of the users of the plugin could not figure out the setting. The plugin constantly reported "Telegram returned an invalid response!".
I added the ability to debug the connection in the functionality of the plugin.
Also, the logic of checking the installation of the hook and the list of associated users was taken to a separate page "Users monitor" to avoid a situation in which it is impossible to disable debugging because the file might not be available for recording.

Also, the situation was eliminated in which php issued a warning about a non-initialized variable.